### PR TITLE
Greatly speed up "equery depends"

### DIFF
--- a/pym/gentoolkit/atom.py
+++ b/pym/gentoolkit/atom.py
@@ -227,10 +227,9 @@ class Atom(portage.dep.Atom, CPV):
 			this_slot != that_slot):
 			return False
 
-		# TODO: Uncomment when Portage's Atom supports repo
-		#if (self.repo_name is not None and other.repo_name is not None and
-		#   self.repo_name != other.repo_name):
-		#   return False
+		if (self.repo is not None and other.repo is not None and
+			self.repo != other.repo):
+			return False
 
 		# Use deps are similar: if one of us forces a flag on and the
 		# other forces it off we do not intersect. If only one of us

--- a/pym/gentoolkit/atom.py
+++ b/pym/gentoolkit/atom.py
@@ -209,15 +209,9 @@ class Atom(portage.dep.Atom, CPV):
 		# Our "cp" (cat/pkg) must match exactly:
 		if self.cp != other.cp:
 			# Check to see if one is name only:
-			# Avoid slow partitioning if we're definitely not matching
-			# (yes, this is hackish, but it's faster):
-			if self.cp[-1:] != other.cp[-1:]:
-				return False
-
-			if ((not self.category and self.name == other.name) or
-				(not other.category and other.name == self.name)):
-				return True
-			return False
+			# We don't bother checking if self.category is None: it can't be
+			# because we're an Atom subclass and that would be invalid.
+			return (not other.category and self.name == other.name)
 
 		# Slot dep only matters if we both have one. If we do they
 		# must be identical:

--- a/pym/gentoolkit/test/test_atom.py
+++ b/pym/gentoolkit/test/test_atom.py
@@ -126,9 +126,8 @@ class TestGentoolkitAtom(unittest.TestCase):
 			('=cat/pkg-1-r1*', '<cat/pkg-1-r1', False),
 			('=cat/pkg-1*', '>cat/pkg-2', False),
 			('>=cat/pkg-8.4', '=cat/pkg-8.3.4*', False),
-			# Repos not yet supported by Portage
-			#('cat/pkg::gentoo', 'cat/pkg', True),
-			#('cat/pkg::gentoo', 'cat/pkg::foo', False),
+			('cat/pkg::gentoo', 'cat/pkg', True),
+			('cat/pkg::gentoo', 'cat/pkg::foo', False),
 			('=sys-devel/gcc-4.1.1-r3', '=sys-devel/gcc-3.3*', False),
 			('=sys-libs/db-4*', '~sys-libs/db-4.3.29', True),
 		]:

--- a/pym/gentoolkit/test/test_atom.py
+++ b/pym/gentoolkit/test/test_atom.py
@@ -8,6 +8,7 @@
 import unittest
 
 from gentoolkit.atom import Atom
+from gentoolkit.cpv import CPV
 from gentoolkit.test import cmp
 
 """Atom test suite (verbatim) from pkgcore."""
@@ -140,10 +141,16 @@ class TestGentoolkitAtom(unittest.TestCase):
 				result, that_atom.intersects(this_atom),
 				'%s intersecting %s should be %s' % (that, this, result))
 
+	def test_intersects_nameonly(self):
+		atom = Atom('cat/pkg')
+		self.assertTrue(atom.intersects(CPV('pkg')))
+		self.assertFalse(atom.intersects(CPV('other')))
+		self.assertFalse(atom.intersects(CPV('dkg')))
+
 
 def test_main():
-        suite = unittest.TestLoader().loadTestsFromTestCase(TestGentoolkitAtom)
-        unittest.TextTestRunner(verbosity=2).run(suite)
+		suite = unittest.TestLoader().loadTestsFromTestCase(TestGentoolkitAtom)
+		unittest.TextTestRunner(verbosity=2).run(suite)
 test_main.__test__ = False
 
 


### PR DESCRIPTION
Avoid `Atom` instanciation in obvious non-matches (`.cp` not matching)
when search for revdeps. On my machine, it made `equery d -a
dev-python/pillow` go from `1m3s` to `0m20s`.