### PR TITLE
Add functional tests through "cmdtests"

### DIFF
--- a/cmdtests/README.txt
+++ b/cmdtests/README.txt
@@ -1,0 +1,16 @@
+Use the "runtests.sh" script to test the output of all commands in "cmds.txt"
+against the output that the version of gentoolkit installed on the system
+yields.
+
+It's a great way to verify that a refactoring didn't affect output.
+
+Usage:
+
+$ cd cmdtests
+$ ./runtests.sh
+
+You can also test against a specific version of gentoolkit instead. Clone a
+copy of gentoolkit to test against and then do:
+
+$ cd cmdtests
+$ ./runtests.sh /path/to/othergentoolkit/pym

--- a/cmdtests/cmds.txt
+++ b/cmdtests/cmds.txt
@@ -1,0 +1,3 @@
+equery meta dev-lang/python
+equery d -a llvm
+equery l "vim*"

--- a/cmdtests/runtests.sh
+++ b/cmdtests/runtests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+TEST_AGAINST_PYTHON_PATH=$1
+
+while read -r line; do
+    echo "Running $line > before"
+    PYTHONPATH="${TEST_AGAINST_PYTHON_PATH}"
+    eval "$line" > before || exit 1
+    echo "Running $line > after"
+    PYTHONPATH="../pym"
+    eval "$line" > after || exit 1
+    DIFF=$(diff -u before after)
+    if [[ -n $DIFF ]]; then
+        echo "Different!"
+        echo "$DIFF"
+        exit 1
+    fi
+done < cmds.txt
+
+rm before after
+echo "All commands output the exact same thing!"


### PR DESCRIPTION
These tests run a list of commands on both the system gentoolkit and the
source from the active work directory, and then compares the results.

It's a great way to verify that a refactoring didn't introduce an
unwanted change in behavior.