### PR TITLE
Fix pass_through_options in revdep-rebuild

### DIFF
--- a/pym/gentoolkit/revdep_rebuild/rebuild.py
+++ b/pym/gentoolkit/revdep_rebuild/rebuild.py
@@ -65,34 +65,33 @@ def init_logger(settings):
 def rebuild(logger, assigned, settings):
 	"""rebuilds the assigned pkgs"""
 
-	args = settings['pass_through_options']
+	args = list(settings['pass_through_options'])
 	if settings['EXACT']:
 		_assigned = filter_masked(assigned, logger)
-		emerge_command = '=' + ' ='.join(_assigned)
+		emerge_command = ['='+a for a in _assigned]
 	else:
 		_assigned = get_slotted_cps(assigned, logger)
-		emerge_command = ' '.join(_assigned)
+		emerge_command = [a for a in _assigned]
 	if settings['PRETEND']:
-		args += ' --pretend'
+		args.append('--pretend')
 	if settings['VERBOSITY'] >= 2:
-		args += ' --verbose'
+		args.append('--verbose')
 	elif settings['VERBOSITY'] < 1:
-		args += ' --quiet'
+		args.append('--quiet')
 	if settings['nocolor']:
-		args += ' --color n'
+		args.extend(['--color', 'n'])
 
 	if len(emerge_command) == 0:
 		logger.warning(bold('\nThere is nothing to emerge. Exiting.'))
 		return 0
 
 	logger.warning(yellow(
-		'\nemerge') + args +
+		'\nemerge') +  ' ' + ' '.join(args) +
 		' --oneshot --complete-graph=y ' +
-		bold(emerge_command))
+		bold(' '.join(emerge_command)))
 
 	stime = current_milli_time()
-	_args = 'emerge ' + args + ' --oneshot --complete-graph=y ' + emerge_command
-	_args = _args.split()
+	_args = ['emerge'] + args + ['--oneshot', '--complete-graph=y'] + emerge_command
 	success = subprocess.call(_args)
 	ftime = current_milli_time()
 	logger.debug("\trebuild(); emerge call for %d ebuilds took: %s seconds"

--- a/pym/gentoolkit/revdep_rebuild/settings.py
+++ b/pym/gentoolkit/revdep_rebuild/settings.py
@@ -46,7 +46,7 @@ DEFAULTS = {
 		'debug': False,
 		'no-ld-path': False,
 		'no-order': False,
-		'pass_through_options': '',
+		'pass_through_options': [],
 		'stdout': sys.stdout,
 		'stdin': sys.stdin,
 		'stderr': sys.stderr
@@ -121,7 +121,7 @@ def parse_options():
 	if args.library:
 		settings['library'].update(set(args.library))
 	settings['USE_TMP_FILES'] = not args.ignore
-	settings['pass_through_options'] = " " + " ".join(args.portage_options)
+	settings['pass_through_options'].extend(args.portage_options)
 
 	return settings
 

--- a/pym/gentoolkit/revdep_rebuild/settings.py
+++ b/pym/gentoolkit/revdep_rebuild/settings.py
@@ -119,9 +119,9 @@ def parse_options():
 	settings['PRETEND'] = args.pretend
 	settings['nocolor'] = args.nocolor
 	if args.library:
-		settings['library'].update(set(args.library))
+		settings['library'] = set(settings['library']) | set(args.library)
 	settings['USE_TMP_FILES'] = not args.ignore
-	settings['pass_through_options'].extend(args.portage_options)
+	settings['pass_through_options'] = list(settings['pass_through_options']) + args.portage_options
 
 	return settings
 


### PR DESCRIPTION
Fix pass_through_options in revdep-rebuild, to handle args containing spaces.

Currently, pass-through options are first joined into a string, then split by spaces before beeing passed to emerge. This is problematic in case an option contains spaces.

This patch keeps the pass-through options as a list, directly passed to emerge whithout join/split.

**Exemple:**
`revdep-rebuild --library 'libstdc++.so.6' -- --exclude="gcc libreoffice webkit-gtk"`

Currently, will result in the following emerge command:
`emerge --exclude=gcc --autounmask-keep-masks --oneshot --complete-graph libreoffice webkit-gtk ...`
i.e. it will emerge libreoffice and webkit-gtk, which is exactly what we wanted to avoid with the "exclude" command.

After fixing, the new command will be:
`emerge --exclude="gcc libreoffice webkit-gtk" --autounmask-keep-masks --oneshot --complete-graph ...`



