### PR TITLE
Added support for formatted output of equery depends.

### DIFF
--- a/man/equery.1
+++ b/man/equery.1
@@ -177,6 +177,10 @@ Include dependencies that are not installed. This can take a while.
 .br
 Search for both direct and indirect dependencies.
 .HP
+.B \-F, \-\-format=\fITMPL\fP
+.br
+Customize the output format of the matched packages using the template string \fITMPL\fP. See the \fB\-\-format\fP option for \fBlist\fP below for a description of the \fITMPL\fP argument.
+.HP
 .BI "\-\-depth=" "NUM"
 .br
 Limit the indirect dependency tree to a depth of \fINUM\fP. \fB\-\-depth=0\fP is equivalent to not using \fB\-\-indirect\fP.


### PR DESCRIPTION
* Like in other modules it is now possible to format the
  output of the equery module 'depends' with the commandline
  switch '-F'  and TMPL.
* The man page was adujusted.
* The new feature was introduced into depends.py.
  * A new static method 'print_formated' was created.
  * In method 'format_depend' is checked if the new option is present.
  * Depending on the check the PackageFormatter is used to display
    the dependencies.

* New feature was tested on local overlay.