### PR TITLE
metadata: Drop deprecated ElementTree methods

### DIFF
--- a/pym/gentoolkit/metadata.py
+++ b/pym/gentoolkit/metadata.py
@@ -73,8 +73,7 @@ class _Maintainer(object):
 		self.description = None
 		self.restrict = node.get('restrict')
 		self.status = node.get('status')
-		maint_attrs = node.getchildren()
-		for attr in maint_attrs:
+		for attr in node.iter():
 			setattr(self, attr.tag, attr.text)
 
 	def __repr__(self):
@@ -101,7 +100,7 @@ class _Useflag(object):
 		_desc = ''
 		if node.text:
 			_desc = node.text
-		for child in node.getchildren():
+		for child in node.iter():
 			_desc += child.text if child.text else ''
 			_desc += child.tail if child.tail else ''
 		# This takes care of tabs and newlines left from the file
@@ -213,7 +212,7 @@ class MetaData(object):
 		if herd in ('no-herd', 'maintainer-wanted', 'maintainer-needed'):
 			return None
 
-		for node in self._herdstree.getiterator('herd'):
+		for node in self._herdstree.iter('herd'):
 			if node.findtext('name') == herd:
 				return node.findtext('email')
 
@@ -283,7 +282,7 @@ class MetaData(object):
 			return self._useflags
 
 		self._useflags = []
-		for node in self._xml_tree.getiterator('flag'):
+		for node in self._xml_tree.iter('flag'):
 			self._useflags.append(_Useflag(node))
 
 		return self._useflags


### PR DESCRIPTION
The getchildren and getiter methods of ElementTree were deprecated in 3.2 and finally removed in 3.9.