### PR TITLE
metadata.py: Don't fail on unmatched package

### DIFF
--- a/bin/equery
+++ b/bin/equery
@@ -29,6 +29,16 @@ except KeyboardInterrupt:
     sys.exit(1)
 
 from gentoolkit import equery, errors
+import warnings
+
+
+def formatwarning(message, category, filename, llineno, line=None):
+    from gentoolkit import pprinter as pp
+    return pp.warn(str(message))
+
+
+if '--debug' not in sys.argv and not bool(os.getenv('DEBUG', False)):
+    warnings.formatwarning = formatwarning
 
 try:
     equery.main(sys.argv)

--- a/pym/gentoolkit/equery/meta.py
+++ b/pym/gentoolkit/equery/meta.py
@@ -13,6 +13,7 @@ __docformat__ = "epytext"
 import re
 import os
 import sys
+import warnings
 from getopt import gnu_getopt, GetoptError
 
 import gentoolkit.pprinter as pp
@@ -524,7 +525,8 @@ def main(input_args):
         best_match = query.find_best()
         matches = query.find(include_masked=True)
         if best_match is None or not matches:
-            raise errors.GentoolkitNoMatches(query)
+            warnings.warn(errors.GentoolkitNoMatches(query))
+            continue
 
         if best_match.metadata is None:
             print(


### PR DESCRIPTION
Added a warning hook too to reuse the GentoolkitNoMatches machinery

This allows users to do something like:

    equery list @selected | xargs equery metadata

successfuly, even if there are some selected packages that don't exist anymore.

Signed-off-by: Marco Sirabella <marco@sirabella.org>