### PR TITLE
*/*: drop obsolete Changelog references

### DIFF
--- a/bin/ebump
+++ b/bin/ebump
@@ -39,9 +39,7 @@ print_usage() {
 	echo "  -v|--verbose           increase verbosity"
 	echo "  -q|--quiet             turn off output"
 	echo "  -a|--no-auxfiles       don't bump auxfiles (files/*)"
-	echo "  -c|--no-changelog      do not update ChangeLog (via echangelog)"
 	echo "  -C|--no-vcs            do not add to VCS"
-	echo "  -m|--message           append message to ChangeLog"
 	echo "  -d|--delete-old        delete previous revision from VCS (DANGEROUS!)"
 }
 
@@ -55,16 +53,8 @@ load_options() {
 	if [ -f "/etc/gentoolkit/ebump.conf" ] ; then
 		. /etc/gentoolkit/ebump.conf
 	fi
-	if [ -f "${HOME}/.gentoo/gentool-env" ] ; then
-		. ${HOME}/.gentoo/gentool-env
-	fi
 	if [ -f "${HOME}/.gentoo/ebump.conf" ] ; then
 		. ${HOME}/.gentoo/ebump.conf
-	fi
-
-	# FIXME: remove this warning in 2-3 releases.
-	if [ -n "${opt_add_cvs}" ]; then
-		echo "Warning: opt_add_cvs is deprecated, please use opt_add_vcs from now on!" >&2
 	fi
 }
 
@@ -276,26 +266,6 @@ process_ebuild() {
 		fi
 		einfo "Removed ${delfiles} from VCS"
 	fi
-
-	#
-	# (Optional) Add ChangeLog entry
-	#
-	if [ "${opt_add_changelog}" = "y" ] && [ "${opt_add_vcs}" = "y" ]; then
-		# FIXME: remove this warning in 2-3 releases
-		if [ -n "${AUTHORNAME}" ] || [ -n "${AUTHOREMAIL}" ]; then
-			echo "Warning: AUTHORNAME and AUTHOREMAIL is deprecated!" >&2
-			echo "Please take a look at echangelog(1)." >&2
-			echo "To avoid this warning unset AUTHORNAME and AUTHOREMAIL." >&2
-		fi
-
-		echangelog "${opt_commitmessage}" || set $?
-
-		if [ ${1:-0} -ne 0 ]; then
-			einfo "Modifying ChangeLog failed!"
-		else
-			einfo "Added ChangeLog entry"
-		fi
-	fi
 }
 
 get_vcs() {
@@ -322,7 +292,6 @@ get_vcs() {
 # Global options
 #
 opt_verbosity=0
-opt_add_changelog=y
 opt_add_vcs=y
 opt_bump_auxfiles=y
 opt_delete_old=n
@@ -346,10 +315,6 @@ while [ ${#} -gt 0 ] ; do
 		;;
 		-a|--no-auxfiles)
 			opt_bump_auxfiles=n
-			continue
-		;;
-		-c|--no-changelog)
-			opt_add_changelog=n
 			continue
 		;;
 		-C|--no-vcs)

--- a/man/ebump.1
+++ b/man/ebump.1
@@ -55,21 +55,6 @@ Do not output any non-essential information.
 don't bump auxfiles (files/*)
 
 .LP
-\fB\-c\fR
-.br
-\fB--no-changelog\fB
-.IP
-do not update ChangeLog (via echangelog)
-
-.LP
-\fB\-m\fR <\fIChangeLog text\fR>
-.br
-\fB\--message\fR <\fIChangeLog text\fR>
-.IP
-Specifies the message to add to the ChangeLog, instead of the standard
-placeholder.
-
-.LP
 \fB\-d\fR
 .br
 \fB\--delete-old\fR
@@ -96,28 +81,16 @@ From these files, \fIebump\fR will load the settings
 .br
 \fBopt_verbosity\fR (default \fI1\fR) - verbosity level 0-10
 .br
-\fBopt_add_changelog\fR (default \fIy\fR) - add entry in ChangeLog
-.br
 \fBopt_add_vcs\fR (default \fIy\fR) - add new files to VCS
 .br
 \fBopt_bump_auxfiles\fR (default \fIy\fR) - bump auxiliary files in files/
 .br
 \fBopt_delete_old\fR (default \fIn\fR) - delete old revision (DANGEROUS!)
-.br
-\fBopt_commitmessage\fR (default \fI""\fR) - default ChangeLog message
-
-.LP
-\fB(DEPRECATED)\fR
-.br
-\fB~/.gentoo/gentool-env\fR
-.IR
-From this file, \fIebump\fR will load the env vars \fBAUTHORNAME\fR and
-\fBAUTHOREMAIL\fR, which are used to generate proper ChangeLog entries.
 
 .SH "SEE ALSO"
 .LP
 The rest of the utilities in \fIapp-portage/gentoolkit-dev\fR, such as
-\fIechangelog(1)\fR and \fIekeyword(1)\fR.
+\fIekeyword(1)\fR.
 
 .SH "AUTHORS"
 .LP

--- a/pym/gentoolkit/ekeyword/ekeyword.py
+++ b/pym/gentoolkit/ekeyword/ekeyword.py
@@ -415,12 +415,7 @@ def ignorable_arg(arg, quiet=0):
         "metadata.xml",
     )
     base = os.path.basename(arg)
-    if (
-        base.startswith("ChangeLog")
-        or base in WHITELIST
-        or base.startswith(".")
-        or base.endswith("~")
-    ):
+    if base in WHITELIST or base.startswith(".") or base.endswith("~"):
         if not quiet:
             warning("ignoring file: %s" % arg)
         return True


### PR DESCRIPTION
We got rid of Changelogs years ago in ::gentoo and most Portage
support is gone too.

Signed-off-by: Sam James <sam@gentoo.org>