### PR TITLE
Drop mentions of linguas

### DIFF
--- a/man/equery.1
+++ b/man/equery.1
@@ -543,9 +543,9 @@ Display USE flag statuses and descriptions for a given \fRPKG\fP.
 .br
 Display all package versions. Without this option, \fBequery\fP will choose the best available version.
 .HP
-.B \-i, \-\-ignore\-linguas
+.B \-i, \-\-ignore\-l10n
 .br
-Do not show the linguas USE flags
+Do not show the l10n USE flags
 .P
 .I R "EXAMPLES" ":"
 .EX

--- a/pym/gentoolkit/equery/uses.py
+++ b/pym/gentoolkit/equery/uses.py
@@ -190,8 +190,7 @@ def get_output_descriptions(pkg, global_usedesc):
 
     if QUERY_OPTS["ignore_l10n"]:
         for a in usevar[:]:
-            # TODO: Remove linguas after transition to l10n is complete
-            if a.startswith("l10n_") or a.startswith("linguas_"):
+            if a.startswith("l10n_"):
                 usevar.remove(a)
 
     if pkg.is_installed():


### PR DESCRIPTION
Hi, the equery man --ignore-l10n/linguas option is outdated. While fixing it I noticed that the special treatment in ignore behavior linguas got is no longer necessary.