### PR TITLE
revdep-rebuild: set up a child logger with propagate = False

### DIFF
--- a/pym/gentoolkit/eshowkw/display_pretty.py
+++ b/pym/gentoolkit/eshowkw/display_pretty.py
@@ -125,6 +125,6 @@ class string_rotator:
             if x.find("+ -") != -1:
                 x = x.replace(" ", "-")
             # strip all chars and remove empty lines
-            if not strip or len(x.strip(" |-")) > 0 or '-' in x:
+            if not strip or len(x.strip(" |-")) > 0 or "-" in x:
                 tmp.append(x)
         return tmp

--- a/pym/gentoolkit/revdep_rebuild/rebuild.py
+++ b/pym/gentoolkit/revdep_rebuild/rebuild.py
@@ -44,7 +44,8 @@ __productname__ = "revdep-ng"
 
 def init_logger(settings):
     """Creates and iitializes our logger according to the settings"""
-    logger = logging.getLogger()
+    logger = logging.getLogger(__name__)
+    logger.propagate = False
     log_handler = logging.StreamHandler(sys.stdout)
     log_fmt = logging.Formatter("%(msg)s")
     log_handler.setFormatter(log_fmt)


### PR DESCRIPTION
This prevents log messages from being emitted more than once, especially
by the root level loggger.

Bug: https://bugs.gentoo.org/838406