### PR TITLE
profile: Default to main repo name

### DIFF
--- a/pym/gentoolkit/profile.py
+++ b/pym/gentoolkit/profile.py
@@ -21,21 +21,26 @@ def warning(msg):
     print("warning: %s" % msg, file=sys.stderr)
 
 
-def load_profile_data(portdir=None, repo="gentoo"):
+def load_profile_data(portdir=None, repo=""):
     """Load the list of known arches from the tree
 
     Args:
       portdir: The repository to load all data from (and ignore |repo|)
-      repo: Look up this repository by name to locate profile data
+      repo: Look up this repository by name to locate profile data (if empty, uses main repo name)
 
     Returns:
       A dict mapping the keyword to its preferred state:
       {'x86': ('stable', 'arch'), 'mips': ('dev', '~arch'), ...}
     """
     if portdir is None:
-        portdir = (
-            portage.db[portage.root]["vartree"].settings.repositories[repo].location
-        )
+        repos = portage.db[portage.root]["vartree"].settings.repositories
+        if repo == "":
+            main_repo = repos.mainRepo()
+            if main_repo is None:
+                repo = "gentoo"
+            else:
+                repo = main_repo.name
+        portdir = repos[repo].location
 
     arch_status = {}
 


### PR DESCRIPTION
In Flatcar we have a different repo marked as a default one (portage-stable), so "equery keywords" was crashing because it was trying to use gentoo repo anyways.

(Tried formatting the file with `black` and it also reformatted some unrelated parts of file. I left them out.)