### PR TITLE
eclean: Strip libc dependencies from --changed-deps calculations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       # TODO: get this dynamically
-      PORTAGE_VERSION: "3.0.45.3"
+      PORTAGE_VERSION: "3.0.57"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/921679