### PR TITLE
Feature/remove legacy text handling

### DIFF
--- a/pym/gentoolkit/equery/belongs.py
+++ b/pym/gentoolkit/equery/belongs.py
@@ -52,7 +52,7 @@ class BelongsPrinter:
             name = pkg.cp
         else:
             name = str(pkg.cpv)
-        pp.uprint(name)
+        print(name)
 
     def print_verbose(self, pkg, cfile):
         "Format for full output."
@@ -61,7 +61,7 @@ class BelongsPrinter:
             name = pkg.cp
         else:
             name = str(pkg.cpv)
-        pp.uprint(pp.cpv(name), "(" + file_str + ")")
+        print(pp.cpv(name), "(" + file_str + ")")
 
 
 # =========

--- a/pym/gentoolkit/equery/belongs.py
+++ b/pym/gentoolkit/equery/belongs.py
@@ -135,7 +135,7 @@ def main(input_args):
         sys.exit(2)
 
     if CONFIG["verbose"]:
-        pp.uprint(" * Searching for %s ... " % (pp.regexpquery(",".join(queries))))
+        print(" * Searching for %s ... " % (pp.regexpquery(",".join(queries))))
 
     printer_fn = BelongsPrinter(
         verbose=CONFIG["verbose"], name_only=QUERY_OPTS["name_only"]

--- a/pym/gentoolkit/equery/check.py
+++ b/pym/gentoolkit/equery/check.py
@@ -218,10 +218,10 @@ def checks_printer(cpv, data, verbose=True, only_failures=False):
     else:
         if verbose:
             if not cpv in seen:
-                pp.uprint("* Checking %s ..." % (pp.emph(str(cpv))))
+                print("* Checking %s ..." % (pp.emph(str(cpv))))
                 seen.append(cpv)
         else:
-            pp.uprint("%s:" % cpv, end=" ")
+            print("%s:" % cpv, end=" ")
 
     if verbose:
         for err in errs:

--- a/pym/gentoolkit/equery/depends.py
+++ b/pym/gentoolkit/equery/depends.py
@@ -55,13 +55,13 @@ class DependPrinter:
         """Verbosely prints a set of dep strings."""
 
         sep = " ? " if (depatom and use_conditional) else ""
-        pp.uprint(indent + pp.cpv(cpv), "(" + use_conditional + sep + depatom + ")")
+        print(indent + pp.cpv(cpv), "(" + use_conditional + sep + depatom + ")")
 
     @staticmethod
     def print_quiet(indent, cpv, use_conditional, depatom):
         """Quietly prints a subset set of dep strings."""
 
-        pp.uprint(indent + cpv)
+        print(indent + cpv)
 
     @staticmethod
     def print_formated(pkg):


### PR DESCRIPTION
This PR removes legacy Python text handling logic in the pprinter module.

This change does cause slightly different whitespace to be printed for certain things, a diff for "equery depgraph" is shown below.

I'm not sure whether the new output should be considered the correct output or whether we should emulate what it was doing before! 

```diff
--- /tmp/gentoolkit-test-8sWVDB/alpha.txt	2024-02-01 18:25:33.659201947 -0500
+++ /tmp/gentoolkit-test-8sWVDB/beta.txt	2024-02-01 18:25:34.152539561 -0500
@@ -1,3 +1,4 @@
+
 dev-lang/python-2.7.18_p16-r1:
  [  0]  dev-lang/python-2.7.18_p16-r1
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -30,6 +31,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.8.18:
  [  0]  dev-lang/python-3.8.18
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -64,6 +66,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.9.18:
  [  0]  dev-lang/python-3.9.18
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -99,6 +102,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.10.13:
  [  0]  dev-lang/python-3.10.13
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -136,6 +140,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.11.7:
  [  0]  dev-lang/python-3.11.7
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -174,6 +179,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.12.1:
  [  0]  dev-lang/python-3.12.1
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -214,6 +220,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.12.1_p1:
  [  0]  dev-lang/python-3.12.1_p1
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -254,6 +261,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.13.0_alpha2:
  [  0]  dev-lang/python-3.13.0_alpha2
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -293,6 +301,7 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
+
 dev-lang/python-3.13.0_alpha3:
  [  0]  dev-lang/python-3.13.0_alpha3
  [  1]  app-arch/bzip2-1.0.8-r4
@@ -332,12 +341,3 @@
  [  1]  dev-build/autoconf-2.71-r6
  [  1]  app-crypt/gnupg-2.2.41
  [  1]  app-portage/gemato-20.5
-
-
-
-
-
-
-
-
-```