### PR TITLE
Feature/unify get depends

### DIFF
--- a/pym/gentoolkit/dependencies.py
+++ b/pym/gentoolkit/dependencies.py
@@ -11,6 +11,8 @@ __all__ = ("Dependencies",)
 # Imports
 # =======
 
+from enum import StrEnum
+
 import portage
 from portage.dep import paren_reduce
 
@@ -22,6 +24,14 @@ from gentoolkit.query import Query
 # =======
 # Classes
 # =======
+
+
+class DependencyKind(StrEnum):
+    DEPEND = "DEPEND"
+    RDEPEND = "RDEPEND"
+    BDEPEND = "BDEPEND"
+    PDEPEND = "PDEPEND"
+    IDEPEND = "IDEPEND"
 
 
 class Dependencies(Query):


### PR DESCRIPTION
This PR merges some methods on the gentoolkit.dependencies Dependencies class into a single method that uses an enum to handle different depend kinds. This removes duplicated code and introduces some type annotations.

It also replaces some manual dep caching with functools.cache, and improves performance of indirect reverse depends searching by many times on my system!