### PR TITLE
Add unit tests and partially rewrite method to pass tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         python -m site
         python -m pip install --upgrade pip
         # setuptools needed for 3.12+ because of https://github.com/mesonbuild/meson/issues/7702.
-        python -m pip install meson ninja setuptools
+        python -m pip install meson ninja setuptools pytest
     - name: Install portage
       run: |
         mkdir portage

--- a/meson.build
+++ b/meson.build
@@ -39,12 +39,8 @@ endif
 subdir('bin')
 subdir('pym')
 
-test(
-    'python-unittest',
-    py,
-    args : ['-m', 'unittest', 'discover', meson.current_source_dir() / 'pym'],
-    timeout : 0
-)
+pytest = find_program('pytest')
+test('pytest', pytest, args : ['-v', meson.current_source_dir() / 'pym'])
 
 if get_option('code-only')
     subdir_done()

--- a/pym/gentoolkit/equery/depends.py
+++ b/pym/gentoolkit/equery/depends.py
@@ -17,7 +17,6 @@ import gentoolkit.pprinter as pp
 from gentoolkit.dependencies import Dependencies
 from gentoolkit.equery import format_options, mod_usage, CONFIG
 from gentoolkit.helpers import get_cpvs, get_installed_cpvs
-from gentoolkit.cpv import CPV
 from gentoolkit.package import PackageFormatter, Package
 
 # =======
@@ -27,7 +26,7 @@ from gentoolkit.package import PackageFormatter, Package
 QUERY_OPTS = {
     "include_masked": False,
     "only_direct": True,
-    "max_depth": -1,
+    "max_depth": None,
     "package_format": None,
 }
 
@@ -94,9 +93,9 @@ class DependPrinter:
         if dep_is_displayed and not self.verbose:
             return
 
-        depth = getattr(dep, "depth", 0)
+        depth = dep.depth
         indent = " " * depth
-        mdep = dep.matching_dep
+        mdep = dep.depatom
         use_conditional = ""
 
         if QUERY_OPTS["package_format"] != None:
@@ -226,17 +225,25 @@ def main(input_args):
 
         if CONFIG["verbose"]:
             print(" * These packages depend on %s:" % pp.emph(pkg.cpv))
-        if pkg.graph_reverse_depends(
-            pkgset=sorted(pkggetter(), key=CPV),
-            max_depth=QUERY_OPTS["max_depth"],
-            only_direct=QUERY_OPTS["only_direct"],
-            printer_fn=dep_print,
-        ):
-            got_match = True
 
         first_run = False
 
-    if not got_match:
+        last_seen = None
+        for pkgdep in pkg.graph_reverse_depends(
+            pkgset=sorted(pkggetter()),
+            only_direct=QUERY_OPTS["only_direct"],
+            max_depth=QUERY_OPTS["max_depth"],
+        ):
+            if last_seen is None or last_seen != pkgdep:
+                seen = False
+            else:
+                seen = True
+            printer(pkgdep, dep_is_displayed=seen)
+            last_seen = pkgdep
+        if last_seen is not None:
+            got_match = True
+
+    if got_match is None:
         sys.exit(1)
 
 

--- a/pym/gentoolkit/equery/depends.py
+++ b/pym/gentoolkit/equery/depends.py
@@ -35,8 +35,8 @@ QUERY_OPTS = {
 # =======
 
 
-class DependPrinter:
-    """Output L{gentoolkit.dependencies.Dependencies} objects."""
+class Printer:
+    """Output L{gentoolkit.dependencies.Dependencies} objects for equery depends."""
 
     def __init__(self, verbose=True):
         self.verbose = verbose
@@ -83,7 +83,7 @@ class DependPrinter:
             )
 
     def format_depend(self, dep, dep_is_displayed):
-        """Format a dependency for printing.
+        """Format a dependency for printing for equery depends.
 
         @type dep: L{gentoolkit.dependencies.Dependencies}
         @param dep: the dependency to display
@@ -209,7 +209,7 @@ def main(input_args):
     # Output
     #
 
-    dep_print = DependPrinter(verbose=CONFIG["verbose"])
+    printer = Printer(verbose=CONFIG["verbose"])
 
     first_run = True
     got_match = False

--- a/pym/gentoolkit/test/test_dependencies.py
+++ b/pym/gentoolkit/test/test_dependencies.py
@@ -1,0 +1,71 @@
+import portage
+from typing import List, Dict, Optional
+from pytest import MonkeyPatch
+from gentoolkit.dependencies import Dependencies
+
+
+def is_cp_in_cpv(cp: str, cpv: str) -> bool:
+    other_cp, _, _ = portage.pkgsplit(cpv)
+    return cp == other_cp
+
+
+def environment(
+    self: Dependencies,
+    env_vars: List[str],
+    fake_depends: Dict[str, Optional[Dict[str, str]]],
+    fake_pkgs: List[str],
+) -> List[str]:
+    metadata = None
+    for pkg in fake_pkgs:
+        if is_cp_in_cpv(self.cp, pkg):
+            if (metadata := fake_depends[pkg]) is not None:
+                break
+    else:
+        return [""]
+    results = list()
+    for env_var in env_vars:
+        try:
+            value = metadata[env_var]
+        except KeyError:
+            value = ""
+        results.append(value)
+    return results
+
+
+def test_basic_revdeps(monkeypatch: MonkeyPatch) -> None:
+    fake_depends = {
+        "app-misc/root-1.0": None,
+        "app-misc/a-1.0": {"DEPEND": "app-misc/root"},
+        "app-misc/b-1.0": {"DEPEND": "app-misc/a"},
+        "app-misc/c-1.0": {"DEPEND": "app-misc/b"},
+        "app-misc/d-1.0": None,
+    }
+    fake_pkgs = list(fake_depends.keys())
+
+    def e(self, env_vars):
+        return environment(self, env_vars, fake_depends, fake_pkgs)
+
+    monkeypatch.setattr(Dependencies, "environment", e)
+
+    # confirm that monkeypatch is working as expected
+    assert Dependencies("app-misc/root").environment(["DEPEND"]) == [""]
+    assert Dependencies("app-misc/a").environment(["DEPEND"]) == ["app-misc/root"]
+    assert Dependencies("app-misc/b").environment(["DEPEND"]) == ["app-misc/a"]
+    assert Dependencies("app-misc/c").environment(["DEPEND"]) == ["app-misc/b"]
+    assert Dependencies("app-misc/d").environment(["DEPEND"]) == [""]
+
+    assert sorted(
+        pkg.cpv
+        for pkg in Dependencies("app-misc/root").graph_reverse_depends(pkgset=fake_pkgs)
+    ) == ["app-misc/a-1.0"]
+
+    assert sorted(
+        pkg.cpv
+        for pkg in Dependencies("app-misc/root").graph_reverse_depends(
+            pkgset=fake_pkgs, only_direct=False
+        )
+    ) == [
+        "app-misc/a-1.0",
+        "app-misc/b-1.0",
+        "app-misc/c-1.0",
+    ]


### PR DESCRIPTION
This PR will introduce pytest testing for the gentoolkit.dependencies.Dependencies class's graph_reverse_depends method. The method was not able to pass a trivial test and has been partially rewritten.

graph_reverse_depends has type annotations and is turned into an iterator, it also does not use the callback printer function which is used only for "equery depends".

The equery depends module is changed to handle printing on its own by iterating over the methods items and calling the printer function on the results. 