### PR TITLE
bin/merge-driver-ekeyword: Look for KEYWORDS changes in upstream commit

### DIFF
--- a/bin/merge-driver-ekeyword
+++ b/bin/merge-driver-ekeyword
@@ -131,5 +131,6 @@ def main(argv: Sequence[str]) -> int:
         except OSError:
             sys.exit(-1)
 
+
 if __name__ == "__main__":
     main(sys.argv)

--- a/bin/merge-driver-ekeyword
+++ b/bin/merge-driver-ekeyword
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2 or later
 
 """
@@ -119,11 +119,15 @@ def main(argv: Sequence[str]) -> int:
     B = argv[3]  # %B - filename of the other branch's version
     P = argv[4]  # %P - original path of the file
 
-    # Get changes from %O to %B
-    changes = keyword_changes(O, B)
-    if changes:
-        # Apply O -> B changes to A
+    # Get changes to KEYWORDS= from %O to %B
+    if changes := keyword_changes(O, B):
+        # Apply %O -> %B changes to %A
         result = apply_keyword_changes(A, P, changes)
+        sys.exit(result)
+    # Get changes to KEYWORDS= from %O to %A
+    elif changes := keyword_changes(O, A):
+        # Apply %O -> %A changes to %B
+        result = apply_keyword_changes(B, P, changes)
         sys.exit(result)
     else:
         try:

--- a/bin/merge-driver-ekeyword
+++ b/bin/merge-driver-ekeyword
@@ -14,7 +14,7 @@ import os
 import sys
 import tempfile
 
-from typing import List, Optional, Tuple
+from typing import Optional
 from collections.abc import Sequence
 
 from gentoolkit.ekeyword import ekeyword


### PR DESCRIPTION
Previously we only looked for changes to the KEYWORDS= line in our local commit being rebased. If it contained no changes to KEYWORDS= then the merge-driver gave up.

However our local patch may conflict with an upstream patch that changed KEYWORDS.

In that case, we can look for changes to the KEYWORDS= line in the other patch and try to apply its change to ours.

This happened in gentoo.git commits

- `2c5cd6c4e004 ("sys-fs/squashfs-tools-ng: Stabilize 1.3.0 amd64, #930693")`
- `7129c2e4e5f3 ("sys-fs/squashfs-tools-ng: run elibtoolize in non-live ebuild")`

leading to a rebase mistake in the latter (later fixed by commit `7579afbd4aa1 ("sys-fs/squashfs-tools-ng: stabilize 1.3.0 for amd64")`).

With this patch applied, the merge conflicts are automatically resolved between the two commits regardless of which is "ours" vs "theirs".