### PR TITLE
revdep_rebuild: Fix issue where library is a full path

### DIFF
--- a/pym/gentoolkit/revdep_rebuild/analyse.py
+++ b/pym/gentoolkit/revdep_rebuild/analyse.py
@@ -250,6 +250,11 @@ class LibCheck:
                                     "\tFile %s ignored as it is masked" % filename
                                 )
                                 continue
+                            if l.startswith('/') and os.path.isfile(l):
+                                self.logger.debug(
+                                    "\tLibrary %s is a full path and it exists" % l
+                                )
+                                continue
                             if not bits in found_libs:
                                 found_libs[bits] = {}
                             try:


### PR DESCRIPTION
app-editors/neovim-0.10.0 has one of it's libraries referenced by a full path, which seems to be causing it want to rebuild.

On my system scanelf shows:
   /usr/bin/nvim;nvim;;libluv.so.1,libvterm.so.0,/usr/lib64/lua/5.1/lpeg.so,libmsgpack-c.so.2,libtree-sitter.so.0,libunibilium.so.4,libluajit-5.1.so.2,libm.so.6,libuv.so.1,libc.so.6;ELFCLASS64

In the LibCheck.search() function it was passing
"/usr/lib64/lua/5.1/lpeg.so" to LibCheck.check() which searches by basename, which of course isn't going to match.