### PR TITLE
Closes: https://bugs.gentoo.org/962148 | Fix euse not handling make.conf as dir

### DIFF
--- a/bin/euse
+++ b/bin/euse
@@ -427,8 +427,8 @@ get_useflaglist_ebuild() {
 # get all make.conf files that exist on the system
 get_all_make_conf() {
 	# At least one of the files exists or we would not have made it this far
-        for x in ${ETC}/make.conf ${ETC}/portage/make.conf ${ETC}/portage/make.conf/*; do
-                [ -f "${x}" ] && echo "${x}"
+    for x in ${ETC}/make.conf ${ETC}/portage/make.conf ${ETC}/portage/make.conf/*; do
+    	[ -f "${x}" ] && echo "${x}"
 	done
 }
 # Function: traverse_profile {{{

--- a/bin/euse
+++ b/bin/euse
@@ -427,8 +427,8 @@ get_useflaglist_ebuild() {
 # get all make.conf files that exist on the system
 get_all_make_conf() {
 	# At least one of the files exists or we would not have made it this far
-	for x in ${ETC}/make.conf ${ETC}/portage/make.conf; do
-		[ -e "${x}" ] && echo "${x}"
+        for x in ${ETC}/make.conf ${ETC}/portage/make.conf ${ETC}/portage/make.conf/*; do
+                [ -f "${x}" ] && echo "${x}"
 	done
 }
 # Function: traverse_profile {{{


### PR DESCRIPTION
Per linked bug.

make.conf can be a dir, but euse didn't respect that. 

Now it does!