### PR TITLE
app-portage/gentoolkit: euse - handle make.conf as dir

### DIFF
--- a/bin/euse
+++ b/bin/euse
@@ -427,8 +427,8 @@ get_useflaglist_ebuild() {
 # get all make.conf files that exist on the system
 get_all_make_conf() {
 	# At least one of the files exists or we would not have made it this far
-	for x in ${ETC}/make.conf ${ETC}/portage/make.conf; do
-		[ -e "${x}" ] && echo "${x}"
+	for x in ${ETC}/make.conf ${ETC}/portage/make.conf ${ETC}/portage/make.conf/*; do
+		[ -f "${x}" ] && echo "${x}"
 	done
 }
 # Function: traverse_profile {{{


### PR DESCRIPTION
euse echoes /etc/make.conf and /etc/portage/make.conf back if they exist.

This misses /etc/portage/make.conf/* if it is a dir, and causes euse to attempt to source a dir, throwing an error.

This PR;
- adds /etc/portage/make.conf/* to the list
- checks if they're files with -f  before echoing back

Closes: https://bugs.gentoo.org/962148