### PR TITLE
Drop Python 2 compatibility code

### DIFF
--- a/pym/gentoolkit/eclean/exclude.py
+++ b/pym/gentoolkit/eclean/exclude.py
@@ -7,7 +7,6 @@
 import os
 import re
 import portage
-from portage import _encodings, _unicode_encode
 
 # Misc. shortcuts to some portage stuff:
 listdir = portage.listdir
@@ -78,8 +77,8 @@ def parseExcludeFile(filepath, output):
     output("Parsing Exclude file: " + filepath)
     try:
         file_ = open(
-            _unicode_encode(filepath, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            filepath,
+            encoding="utf-8",
         )
     except OSError:
         raise ParseExcludeFileException("Could not open exclusion file: " + filepath)

--- a/pym/gentoolkit/enalyze/rebuild.py
+++ b/pym/gentoolkit/enalyze/rebuild.py
@@ -26,7 +26,6 @@ from gentoolkit.package import Package
 
 
 import portage
-from portage import _encodings, _unicode_encode
 
 
 def cpv_all_diff_use(
@@ -391,9 +390,9 @@ class Rebuild(ModuleBase):
         if not self.options["quiet"]:
             print("   - Saving file: %s" % filepath)
         with open(
-            _unicode_encode(filepath, encoding=_encodings["fs"]),
+            filepath,
             mode="w",
-            encoding=_encodings["content"],
+            encoding="utf-8",
         ) as output:
             output.write("\n".join(data))
             output.write("\n")

--- a/pym/gentoolkit/equery/uses.py
+++ b/pym/gentoolkit/equery/uses.py
@@ -18,7 +18,6 @@ from getopt import gnu_getopt, GetoptError
 from glob import glob
 
 from portage import settings
-from portage import _encodings, _unicode_encode
 
 import gentoolkit.pprinter as pp
 from gentoolkit import errors
@@ -151,8 +150,8 @@ def get_global_useflags():
     try:
         path = os.path.join(settings["PORTDIR"], "profiles", "use.desc")
         with open(
-            _unicode_encode(path, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            path,
+            encoding="utf-8",
         ) as open_file:
             for line in open_file:
                 if line.startswith("#"):
@@ -171,8 +170,8 @@ def get_global_useflags():
     for path in glob(os.path.join(settings["PORTDIR"], "profiles", "desc", "*.desc")):
         try:
             with open(
-                _unicode_encode(path, encoding=_encodings["fs"]),
-                encoding=_encodings["content"],
+                path,
+                encoding="utf-8",
             ) as open_file:
                 for line in open_file:
                     if line.startswith("#"):

--- a/pym/gentoolkit/equery/which.py
+++ b/pym/gentoolkit/equery/which.py
@@ -22,8 +22,6 @@ from gentoolkit import errors
 from gentoolkit.equery import format_options, mod_usage
 from gentoolkit.query import Query
 
-from portage import _encodings, _unicode_encode
-
 # =======
 # Globals
 # =======
@@ -62,8 +60,8 @@ def print_help(with_description=True):
 def print_ebuild(ebuild_path):
     """Output the ebuild to std_out"""
     with open(
-        _unicode_encode(ebuild_path, encoding=_encodings["fs"]),
-        encoding=_encodings["content"],
+        ebuild_path,
+        encoding="utf-8",
     ) as f:
         lines = f.readlines()
         print("\n\n")

--- a/pym/gentoolkit/eshowkw/__init__.py
+++ b/pym/gentoolkit/eshowkw/__init__.py
@@ -191,7 +191,9 @@ def main(argv, indirect=False):
             for repo in ports.repositories:
                 repos[repo.name] = repo.location
 
-            with open(os.path.join(ourtree, "profiles", "repo_name")) as f:
+            with open(
+                os.path.join(ourtree, "profiles", "repo_name"), encoding="utf-8"
+            ) as f:
                 repo_name = f.readline().strip()
 
             repos[repo_name] = ourtree

--- a/pym/gentoolkit/helpers.py
+++ b/pym/gentoolkit/helpers.py
@@ -28,7 +28,6 @@ from functools import partial
 from itertools import chain
 
 import portage
-from portage import _encodings, _unicode_encode
 
 from gentoolkit import pprinter as pp
 from gentoolkit import errors
@@ -300,7 +299,7 @@ def get_bintree_cpvs(predicate=None):
 def print_file(path):
     """Display the contents of a file."""
 
-    with open(_unicode_encode(path, encoding=_encodings["fs"]), mode="rb") as open_file:
+    with open(path, mode="rb") as open_file:
         lines = open_file.read()
         pp.uprint(lines.strip())
 

--- a/pym/gentoolkit/imlate/imlate.py
+++ b/pym/gentoolkit/imlate/imlate.py
@@ -97,7 +97,7 @@ def show_result(conf, pkgs):
     elif conf["FILE"] == "stderr":
         out = stderr
     else:
-        out = open(conf["FILE"], "w")
+        out = open(conf["FILE"], "w", encoding="utf-8")
 
     if conf["STABLE"] and conf["KEYWORD"]:
         _cand = "%i Stable and %i Keyword(~)" % (

--- a/pym/gentoolkit/merge_driver_ekeyword/merge_driver_ekeyword.py
+++ b/pym/gentoolkit/merge_driver_ekeyword/merge_driver_ekeyword.py
@@ -58,7 +58,7 @@ def keyword_line_changes(old: str, new: str) -> KeywordChanges:
 
 
 def keyword_changes(ebuild1: str, ebuild2: str) -> Optional[KeywordChanges]:
-    with open(ebuild1) as e1, open(ebuild2) as e2:
+    with open(ebuild1, encoding="utf-8") as e1, open(ebuild2, encoding="utf-8") as e2:
         lines1 = e1.readlines()
         lines2 = e2.readlines()
 

--- a/pym/gentoolkit/package.py
+++ b/pym/gentoolkit/package.py
@@ -51,7 +51,6 @@ from string import Template
 
 import portage
 from portage.util import LazyItemsDict
-from portage import _encodings, _unicode_encode
 
 import gentoolkit.pprinter as pp
 from gentoolkit import errors
@@ -397,7 +396,7 @@ class Package(CPV):
         size = n_files = n_uncounted = 0
         for path in self.parsed_contents(prefix_root=True):
             try:
-                st = os.lstat(_unicode_encode(path, encoding=_encodings["fs"]))
+                st = os.lstat(path)
             except OSError:
                 continue
 

--- a/pym/gentoolkit/pprinter.py
+++ b/pym/gentoolkit/pprinter.py
@@ -162,12 +162,6 @@ def warn(string):
     return "!!! " + string + "\n"
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
-
 def uprint(*args, **kw):
     """Replacement for the builtin print function.
 
@@ -199,7 +193,7 @@ def uprint(*args, **kw):
             if isinstance(arg, bytes):
                 yield arg
             else:
-                yield unicode(arg).encode(encoding, "replace")
+                yield str(arg).encode(encoding, "replace")
 
     sep = sep.encode(encoding, "replace")
     end = end.encode(encoding, "replace")

--- a/pym/gentoolkit/profile.py
+++ b/pym/gentoolkit/profile.py
@@ -13,8 +13,6 @@ import os.path
 import portage
 import sys
 
-from portage import _encodings, _unicode_encode
-
 
 def warning(msg):
     """Write |msg| as a warning to stderr"""
@@ -47,8 +45,8 @@ def load_profile_data(portdir=None, repo=""):
     try:
         arch_list = os.path.join(portdir, "profiles", "arch.list")
         with open(
-            _unicode_encode(arch_list, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            arch_list,
+            encoding="utf-8",
         ) as f:
             for line in f:
                 line = line.split("#", 1)[0].strip()
@@ -66,8 +64,8 @@ def load_profile_data(portdir=None, repo=""):
         }
         profiles_list = os.path.join(portdir, "profiles", "profiles.desc")
         with open(
-            _unicode_encode(profiles_list, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            profiles_list,
+            encoding="utf-8",
         ) as f:
             for line in f:
                 line = line.split("#", 1)[0].split()
@@ -91,8 +89,8 @@ def load_profile_data(portdir=None, repo=""):
     try:
         arches_list = os.path.join(portdir, "profiles", "arches.desc")
         with open(
-            _unicode_encode(arches_list, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            arches_list,
+            encoding="utf-8",
         ) as f:
             for line in f:
                 line = line.split("#", 1)[0].split()

--- a/pym/gentoolkit/revdep_rebuild/analyse.py
+++ b/pym/gentoolkit/revdep_rebuild/analyse.py
@@ -6,7 +6,6 @@ import os
 import re
 import time
 
-from portage import _encodings, _unicode_encode
 from portage.output import bold, blue, yellow, green
 
 from .stuff import scan
@@ -91,8 +90,8 @@ def extract_dependencies_from_la(la, libraries, to_check, logger):
             continue
 
         for line in open(
-            _unicode_encode(_file, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            _file,
+            encoding="utf-8",
         ).readlines():
             line = line.strip()
             if line.startswith("dependency_libs="):

--- a/pym/gentoolkit/revdep_rebuild/cache.py
+++ b/pym/gentoolkit/revdep_rebuild/cache.py
@@ -2,7 +2,7 @@
 Functions for reading, saving and verifying the data caches
 """
 
-from portage import os
+import os
 import time
 
 from portage.output import red

--- a/pym/gentoolkit/revdep_rebuild/cache.py
+++ b/pym/gentoolkit/revdep_rebuild/cache.py
@@ -5,7 +5,6 @@ Functions for reading, saving and verifying the data caches
 from portage import os
 import time
 
-from portage import _encodings, _unicode_encode
 from portage.output import red
 from .settings import DEFAULTS
 
@@ -28,10 +27,8 @@ def read_cache(temp_path=DEFAULTS["DEFAULT_TMP_DIR"]):
     try:
         for key, val in ret.items():
             _file = open(
-                _unicode_encode(
-                    os.path.join(temp_path, key), encoding=_encodings["fs"]
-                ),
-                encoding=_encodings["content"],
+                os.path.join(temp_path, key),
+                encoding="utf-8",
             )
             for line in _file.readlines():
                 val.add(line.strip())
@@ -60,22 +57,18 @@ def save_cache(logger, to_save={}, temp_path=DEFAULTS["DEFAULT_TMP_DIR"]):
 
     try:
         _file = open(
-            _unicode_encode(
-                os.path.join(temp_path, "timestamp"), encoding=_encodings["fs"]
-            ),
+            os.path.join(temp_path, "timestamp"),
             mode="w",
-            encoding=_encodings["content"],
+            encoding="utf-8",
         )
         _file.write(str(int(time.time())))
         _file.close()
 
         for key, val in to_save.items():
             _file = open(
-                _unicode_encode(
-                    os.path.join(temp_path, key), encoding=_encodings["fs"]
-                ),
+                os.path.join(temp_path, key),
                 mode="w",
-                encoding=_encodings["content"],
+                encoding="utf-8",
             )
             for line in val:
                 _file.write(line + "\n")
@@ -105,8 +98,8 @@ def check_temp_files(
 
     try:
         _file = open(
-            _unicode_encode(timestamp_path, encoding=_encodings["fs"]),
-            encoding=_encodings["content"],
+            timestamp_path,
+            encoding="utf-8",
         )
         timestamp = int(_file.readline())
         _file.close()

--- a/pym/gentoolkit/revdep_rebuild/collect.py
+++ b/pym/gentoolkit/revdep_rebuild/collect.py
@@ -8,7 +8,6 @@ import glob
 import stat
 
 import portage
-from portage import _encodings, _unicode_encode
 from portage.output import blue, yellow
 from .settings import parse_revdep_config
 
@@ -27,8 +26,8 @@ def parse_conf(conf_file, visited=None, logger=None):
     for conf in conf_file:
         try:
             with open(
-                _unicode_encode(conf, encoding=_encodings["fs"]),
-                encoding=_encodings["content"],
+                conf,
+                encoding="utf-8",
             ) as _file:
                 for line in _file.readlines():
                     line = line.strip()
@@ -75,11 +74,8 @@ def prepare_search_dirs(logger, settings):
 
     # try:
     with open(
-        _unicode_encode(
-            os.path.join(portage.root, settings["DEFAULT_ENV_FILE"]),
-            encoding=_encodings["fs"],
-        ),
-        encoding=_encodings["content"],
+        os.path.join(portage.root, settings["DEFAULT_ENV_FILE"]),
+        encoding="utf-8",
     ) as _file:
         for line in _file.readlines():
             line = line.strip()

--- a/pym/gentoolkit/revdep_rebuild/collect.py
+++ b/pym/gentoolkit/revdep_rebuild/collect.py
@@ -3,7 +3,7 @@
 """Data collection module"""
 
 import re
-from portage import os
+import os
 import glob
 import stat
 

--- a/pym/gentoolkit/revdep_rebuild/settings.py
+++ b/pym/gentoolkit/revdep_rebuild/settings.py
@@ -9,7 +9,6 @@ import re
 import glob
 
 import portage
-from portage import _encodings, _unicode_encode
 
 portage_root = str(portage.root)
 
@@ -158,10 +157,8 @@ def parse_revdep_config(revdep_confdir):
 
     for _file in os.listdir(revdep_confdir):
         for line in open(
-            _unicode_encode(
-                os.path.join(revdep_confdir, _file), encoding=_encodings["fs"]
-            ),
-            encoding=_encodings["content"],
+            os.path.join(revdep_confdir, _file),
+            encoding="utf-8",
         ):
             line = line.strip()
             # first check for comment, we do not want to regex all lines

--- a/pym/gentoolkit/test/eclean/creator.py
+++ b/pym/gentoolkit/test/eclean/creator.py
@@ -10,7 +10,6 @@ import shutil
 import random
 
 import gentoolkit.pprinter as pp
-from portage import _encodings, _unicode_encode
 
 __version__ = "0.0.1"
 __author__ = "Brian Dolbec"
@@ -51,10 +50,10 @@ def make_dist(path, files, clean_dict=None):
         data = "0" * size
         filepath = os.path.join(path, file_)
         with open(
-            _unicode_encode(filepath, encoding=_encodings["fs"]),
+            filepath,
             "w",
             file_mode,
-            encoding=_encodings["content"],
+            encoding="utf-8",
         ) as new_file:
             new_file.write(data)
         if file_ not in clean_dict:


### PR DESCRIPTION
Remove portage._unicode_encode/_encodings wrappers around open() and os.lstat(). These were unnecessary since Python 3 accepts str paths and uses UTF-8 by default on modern systems. Also drop portage.os (a re-export of stdlib os), the Python 2 unicode/str shim in pprinter, and add explicit encoding="utf-8" to the remaining text-mode open() calls that lacked it.