### PR TITLE
atom: fix cp/version corruption from portage's `__slots__`-based Atom (bug 978428)

### DIFF
--- a/pym/gentoolkit/atom.py
+++ b/pym/gentoolkit/atom.py
@@ -70,7 +70,7 @@ class Atom(portage.dep.Atom, CPV):
             self._cp = None
         self._category = None
         self._name = None
-        self._version = None
+        self._bare_version = None
         self._revision = None
         self._fullversion = None
         self.validate = False

--- a/pym/gentoolkit/atom.py
+++ b/pym/gentoolkit/atom.py
@@ -64,15 +64,14 @@ class Atom(portage.dep.Atom, CPV):
         except portage.exception.InvalidAtom:
             raise errors.GentoolkitInvalidAtom(atom)
 
-        # cpv is already managed by portage.dep.Atom; initialize CPV's
-        # private attrs directly to avoid writing to portage's read-only
-        # cpv property (new portage) or redundantly overwriting __dict__
-        # (old portage).
+        # Seed _cp only if portage didn't already set it (old portage never
+        # sets it; new portage's __slots__ value must not be clobbered).
+        if not hasattr(self, "_cp"):
+            self._cp = None
         self._category = None
         self._name = None
         self._version = None
         self._revision = None
-        self._cp = None
         self._fullversion = None
         self.validate = False
 

--- a/pym/gentoolkit/atom.py
+++ b/pym/gentoolkit/atom.py
@@ -56,6 +56,13 @@ class Atom(portage.dep.Atom, CPV):
             op = super().operator
         return "" if op is None else op
 
+    @property
+    def version(self):
+        # New portage's version property includes the revision; ours doesn't.
+        if self._bare_version is None:
+            self._set_cpv_chunks()
+        return self._bare_version
+
     def __init__(self, atom):
         self.atom = atom
 

--- a/pym/gentoolkit/cpv.py
+++ b/pym/gentoolkit/cpv.py
@@ -56,7 +56,7 @@ class CPV:
         self.cpv = cpv
         self._category = None
         self._name = None
-        self._version = None
+        self._bare_version = None
         self._revision = None
         self._cp = None
         self._fullversion = None
@@ -79,9 +79,9 @@ class CPV:
 
     @property
     def version(self):
-        if self._version is None:
+        if self._bare_version is None:
             self._set_cpv_chunks()
-        return self._version
+        return self._bare_version
 
     @property
     def revision(self):
@@ -107,7 +107,7 @@ class CPV:
         chunks = split_cpv(self.cpv, validate=self.validate)
         self._category = chunks[0]
         self._name = chunks[1]
-        self._version = chunks[2]
+        self._bare_version = chunks[2]
         self._revision = chunks[3]
 
     def __eq__(self, other):


### PR DESCRIPTION
Three fixes, bisected against the actual test failures reported in bug 978428:
1. Stop resetting `self._cp` in `Atom.__init__`. portage already sets it correctly.
2. Rename CPV's private version cache from `_version` to `_bare_version` to stop colliding with portage's slot.
3. Add an explicit version property override on `Atom`, since new portage's version keeps the revision embedded (e.g. "2-r1") while gentoolkit's semantics keep it split out via `.revision`.