### PR TITLE
query: fix missing operator attribute on Query objects

### DIFF
--- a/pym/gentoolkit/atom.py
+++ b/pym/gentoolkit/atom.py
@@ -45,6 +45,20 @@ class Atom(portage.dep.Atom, CPV):
     # Necessary for Portage versions < 2.1.7
     _atoms = weakref.WeakValueDictionary()
 
+    def __new__(cls, *args, **kwargs):
+        # portage.dep.Atom.__new__ interns instances in a module-level
+        # cache keyed only by the atom string (not by cls), so calling
+        # this subclass's constructor with an already-interned string can
+        # silently hand back a plain portage.dep.Atom instead of one of
+        # ours. Always build a fresh instance so we stay this subclass.
+        #
+        # Old portage (<= 3.0.81.3) makes Atom a str subclass instead, with
+        # no interning cache, so allocation there must go through
+        # str.__new__ or the instance is unusable as a str.
+        if issubclass(portage.dep.Atom, str):
+            return str.__new__(cls, args[0] if args else "")
+        return object.__new__(cls)
+
     @property
     def operator(self):
         # Old portage stored operator as a plain instance attribute in

--- a/pym/gentoolkit/dependencies.py
+++ b/pym/gentoolkit/dependencies.py
@@ -227,6 +227,16 @@ class Dependencies(Query):
         if seen is None:
             seen = set()
 
+        # self.atom is a real Atom only when the query parsed as a valid
+        # atom; a bare package name (e.g. "simdjson") falls back to a plain
+        # string that Atom.intersects() can't type-check. Pass self instead:
+        # it has the .cp/.category/.name attributes intersects() needs for
+        # its name-only comparison, and since self.cp (unslashed) never
+        # equals dep.cp ("cat/pkg"), that comparison always takes the
+        # early-return branch, so the attributes intersects() doesn't check
+        # (.repo, .slot, etc.) are never touched.
+        target = self.atom if isinstance(self.atom, Atom) else self
+
         for pkgdep in (Dependencies(pkg) for pkg in pkgset):
             if self.cp not in pkgdep.get_raw_depends():
                 # fast path for obviously non-matching packages. This saves
@@ -236,7 +246,7 @@ class Dependencies(Query):
 
             found_match = False
             for dep in pkgdep.get_all_depends():
-                if dep.intersects(self):
+                if dep.intersects(target):
                     pkgdep.depatom = dep
                     pkgdep.depth = depth
                     yield pkgdep

--- a/pym/gentoolkit/query.py
+++ b/pym/gentoolkit/query.py
@@ -60,6 +60,10 @@ class Query(CPV):
             try:
                 atom = Atom(self.query)
                 self.__dict__.update(atom.__dict__)
+                # gentoolkit.atom.Atom.__init__ sets self.atom to the raw
+                # atom string (for __repr__/__str__), clobbering what should
+                # be a reference to the Atom object itself; restore it.
+                self.atom = atom
                 # portage.dep.Atom uses __slots__, so cpv, _cp, and _version
                 # are absent from atom.__dict__; initialize them explicitly so
                 # CPV's lazy property accessors don't raise AttributeError.
@@ -75,7 +79,13 @@ class Query(CPV):
             except errors.GentoolkitInvalidAtom:
                 CPV.__init__(self, self.query)
                 self.operator = ""
-                self.atom = self.cpv
+                # self.cpv may contain glob/regex wildcards (e.g. from a
+                # regex query), which aren't valid atom syntax; fall back to
+                # the plain string in that case.
+                try:
+                    self.atom = Atom(f"={self.cpv}")
+                except errors.GentoolkitInvalidAtom:
+                    self.atom = self.cpv
 
     def __repr__(self):
         rx = ""

--- a/pym/gentoolkit/query.py
+++ b/pym/gentoolkit/query.py
@@ -68,6 +68,10 @@ class Query(CPV):
                 for _attr in ("_version", "_cp"):
                     if _attr not in self.__dict__:
                         setattr(self, _attr, None)
+                # gentoolkit.atom.Atom's operator is a read-only @property,
+                # never a plain instance attribute, so it's never in
+                # atom.__dict__ either.
+                self.operator = atom.operator
             except errors.GentoolkitInvalidAtom:
                 CPV.__init__(self, self.query)
                 self.operator = ""


### PR DESCRIPTION
portage.dep.Atom now uses `__slots__` and exposes operator as a read-only `@property` backed by `_operator`, so it no longer appears in `atom.__dict__`. `Query.__init__` copies `atom.__dict__` into `self` but never picked up `operator`, same gap already patched here for `cpv`, `_version`, and `_cp`. `Dependencies` (a `Query` subclass) then lacked `.operator` entirely, crashing `equery d` with `AttributeError` when `Atom.intersects()` compared against it.

Bug: https://bugs.gentoo.org/981521